### PR TITLE
Get rid of UserHooks

### DIFF
--- a/src/PythiaMain.cxx
+++ b/src/PythiaMain.cxx
@@ -131,8 +131,8 @@ int main(int argc, char **argv){
   }
 
   if(hooksArg.getValue() != ""){
-    Sacrifice::UserHooksFactory::loadLibrary(libArg.getValue());
-    if(!pythia.setUserHooksPtr(Sacrifice::UserHooksFactory::create(hooksArg.getValue())))
+//    Sacrifice::UserHooksFactory::loadLibrary(libArg.getValue());
+//    if(!pythia.setUserHooksPtr(Sacrifice::UserHooksFactory::create(hooksArg.getValue())))
       throw std::runtime_error("Unable to use UserHook: " + hooksArg.getValue());
   }
 


### PR DESCRIPTION
for the time being. 
This is because the API has changed in Pythia8.3 wrt. Pythia8.2 and I want to fix it in the quickest way as possible.
Better fixes are possible.